### PR TITLE
ci(github-action): push docker image to github container registry

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -162,12 +162,12 @@ jobs:
       - name: View current docker images
         run: docker images
 
-      # - name: Push Docker images to GitHub Container Registry
-      #   # only push if on master branch AND there's a new version to push
-      #   if: ${{ github.ref == 'refs/heads/master' && env.NEXT_VERSION != env.LATEST_GIT_TAG }}
-      #   run: |
-      #     docker push ${{ env.GHCR_IMAGE }}:latest
-      #     docker push ${{ env.GHCR_IMAGE }}:${{ env.NEXT_VERSION }}
+      - name: Push Docker images to GitHub Container Registry
+        # only push if on master branch AND there's a new version to push
+        if: ${{ github.ref == 'refs/heads/master' && env.NEXT_VERSION != env.LATEST_GIT_TAG }}
+        run: |
+          docker push ${{ env.GHCR_IMAGE }}:latest
+          docker push ${{ env.GHCR_IMAGE }}:${{ env.NEXT_VERSION }}
 
       - name: store NEXT_VERSION and LATEST_GIT_TAG to github output
         id: dockerBuild-output


### PR DESCRIPTION
- push docker image to github container registry
- push docker image IF NEXT_VERSION and LATEST_GIT_TAG are not equal
  - This to prevent pushing if semantic-release has no new release created
- docker image name have the following structure
  - `ghcr.io/clumsy-coder/pihole-dashboard:latest`
  - `ghcr.io/clumsy-coder/pihole-dashboard:$NEXT_VERSION`