### PR TITLE
fix(docker): pass .env.local to the final stage of docker image building

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -24,7 +24,7 @@
 
 ####################################################################################################
 
-# Base on offical Node.js Alpine image
+# Base on official Node.js Alpine image
 FROM node:alpine as builder
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
@@ -70,6 +70,7 @@ COPY --from=builder --chown=node:node /usr/app/package.json     ./package.json
 # https://nextjs.org/docs/advanced-features/output-file-tracing
 COPY --from=builder --chown=node:node /usr/app/.next/standalone ./
 COPY --from=builder --chown=node:node /usr/app/.next/static     ./.next/static
+COPY --from=builder --chown=node:node /usr/app/.env.local       ./.env.local
 
 USER node
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "generateVersion": "echo $(npm run -s repoLatestTag)-dev-\"$(npm run -s repoStatus)\"",
     "generateBuildId": "git rev-parse head | cut -c 1-7 2> /dev/null || echo 'development'",
     "generateEnv": "./generateEnvs.sh",
-    "docker:imagename": "echo 'imagename'",
+    "docker:imagename": "echo 'pihole-dashboard'",
     "docker:tagname": "echo $(npm run -s repoLatestTag)-dev-$(npm run -s generateBuildId)-$(npm run -s repoStatus)",
     "docker:build": "npm run generateEnv && docker build -t $(npm run -s docker:imagename):$(npm run -s docker:tagname) -f ./dockerfile .",
     "docker:run": "docker run --rm -e 'PORT=3000' -p 3000:3000 -d --name $(npm run -s docker:imagename) $(npm run -s docker:imagename):$(npm run -s docker:tagname) && echo '\nGo to http://localhost:3000'",


### PR DESCRIPTION
## problem
- the app would not load because the `.env.local` file was not present
  - this is an issue because iron-session uses an ENV to encrypt session cookie content using a password
  - this password is loaded from `.env.local` file
  - if the ENV is not present, the rest of the app will not work

## solution
- copy `.env.local` file from the building stage to the running stage of building docker image

## why
- without the solution
  - iron-session will not work
  - iron-session in NextJS middleware will not work

## where
- ./dockerfile