### PR TITLE
ci(github-action): use latest NodeJS version in each job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,9 @@ jobs:
       npm-cache-dir: ${{ steps.npm-cache-dir.outputs.dir }}
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: latest
 
       - name: Get npm cache directory
         id: npm-cache-dir
@@ -45,6 +48,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: latest
 
       - uses: actions/cache@v3
         id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
@@ -73,6 +79,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: latest
 
       - uses: actions/cache@v3
         id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
@@ -190,6 +199,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+      - uses: actions/setup-node@v3
+        with:
+          node-version: latest
 
       - uses: actions/cache@v3
         id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## what
- use latest NodeJS version for each job

## how
- using github action `setup-node` to install latest node version
  - check https://github.com/actions/setup-node

## why
- semantic release `v20.0.0` requires NodeJS v18
  - check #233

## where
- .github/workflows/build.yaml

## usage