### PR TITLE
refactor(api): provide auth token when fetching `summary` and `summaryRaw` from upstream

### DIFF
--- a/src/pages/api/queries/summary.ts
+++ b/src/pages/api/queries/summary.ts
@@ -50,8 +50,8 @@ const handleGetSummaryRaw = (
   res: NextApiResponse<IGetSummaryRawResponseData | ErrorMessage>,
 ) => {
   const getLogger = logger.scope('/api/summary', 'GET', 'raw');
-  const { ipAddress, port } = req.session.authSession;
-  const requestUrl = `http://${ipAddress}:${port}/${summaryRawUrl()}`;
+  const { ipAddress, port, password } = req.session.authSession;
+  const requestUrl = `http://${ipAddress}:${port}/${summaryRawUrl()}&auth=${password}`;
 
   axios
     .get<ISummaryRaw>(requestUrl)
@@ -81,8 +81,8 @@ const handleGetSummary = (
   res: NextApiResponse<IGetSummaryResponseData | ErrorMessage>,
 ) => {
   const getLogger = logger.scope('/api/summary', 'GET', 'formatted');
-  const { ipAddress, port } = req.session.authSession;
-  const requestUrl = `http://${ipAddress}:${port}/${summaryUrl()}`;
+  const { ipAddress, port, password } = req.session.authSession;
+  const requestUrl = `http://${ipAddress}:${port}/${summaryUrl()}&auth=${password}`;
 
   axios
     .get<ISummary>(requestUrl)


### PR DESCRIPTION
  ## what
  - provide auth token when fetching `summary` and `summaryRaw` from upstream

  ## how
  - add `auth=${password}` at the end of the URL

  ## why
  - Pi-hole now requires auth token when fetching `summary` and `summaryRaw`
    - check https://discourse.pi-hole.net/t/upcoming-changes-authentication-for-more-api-endpoints-required/59315

  ## where
  - ./src/pages/api/queries/summary.ts

  ## usage