### PR TITLE
refactor(component): navigate to home page using `router.reload` in ` LoginForm` component after a successful authentication

### DIFF
--- a/src/components/LoginForm/index.tsx
+++ b/src/components/LoginForm/index.tsx
@@ -102,8 +102,9 @@ const LoginForm: React.FC = () => {
 
     try {
       await postAuthSession({ ipAddress, password, port }).unwrap();
-      // eslint-disable-next-line no-console
-      router.push('/').catch(console.error);
+      // replaced `router.push('/').catch(console.error);` because it would not navigate to another page.
+      // not sure why this is happening.
+      router.reload()
     } catch (err: unknown) {
       setAuthMessage((err as { data: { message: string } }).data.message);
     }


### PR DESCRIPTION
  ## what
  - use method `router.reload` to navigate to home page after a successful authentication

  ## how
  - replace method `router.push` with `router.reload`

  ## why
  - After upgrading npm package `next` this problem has occurred.
    - not sure when this problem started.
    - for now, using `router.reload` will suffice

  ## where
  - ./src/components/LoginForm/index.tsx

  ## usage